### PR TITLE
Fix syntax error which was causing plugin to return 'ERROR: undefined lo...

### DIFF
--- a/models/vagrant_builder.rb
+++ b/models/vagrant_builder.rb
@@ -85,7 +85,7 @@ module Vagrant
     def perform(build, launcher, listener)
       @vagrant = build.env[:vagrant]
       if @vagrant.nil?
-        built.halt "OH CRAP! I don't seem to have a Vagrant instance"
+        build.halt "OH CRAP! I don't seem to have a Vagrant instance"
       end
 
       unless @vagrant.primary_vm.state == :running


### PR DESCRIPTION
...cal variable or method ' if there was no Vagrant instance.
