### PR TITLE
[FIXED JENKINS-25932] Fix provider argument for vagrant up

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantUpCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantUpCommand.java
@@ -90,7 +90,7 @@ public class VagrantUpCommand extends Builder {
     }
 
     if (provider != null && !provider.isEmpty()) {
-      arg.add(provider);
+      arg.add("--provider=" + provider);
     }
 
     if (this.dontKillMe) {


### PR DESCRIPTION
The provider argument should be `--provider=<provider-name>`.
