### PR TITLE
Jenkins 46233 build env settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,18 +9,17 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>1.532.3</jenkins.version>
+    <jenkins.version>1.625.3</jenkins.version>
     <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
     <java.level>7</java.level>
     <!-- Jenkins Test Harness version you use to test the plugin. -->
     <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-    <jenkins-test-harness.version>1.532.3</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.11</jenkins-test-harness.version>
     <!-- Other properties you may want to use:
          ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
          ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
     -->
   </properties>
-  <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>vagrant</artifactId>
   <version>1.0.3-SNAPSHOT</version>
   <packaging>hpi</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,17 +9,18 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>1.532.3</jenkins.version>
     <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
     <java.level>7</java.level>
     <!-- Jenkins Test Harness version you use to test the plugin. -->
     <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-    <jenkins-test-harness.version>2.11</jenkins-test-harness.version>
+    <jenkins-test-harness.version>1.532.3</jenkins-test-harness.version>
     <!-- Other properties you may want to use:
          ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
          ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
     -->
   </properties>
+  <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>vagrant</artifactId>
   <version>1.0.3-SNAPSHOT</version>
   <packaging>hpi</packaging>

--- a/src/main/java/org/jenkinsci/plugins/vagrant/PerformVagrantDestroy.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/PerformVagrantDestroy.java
@@ -1,0 +1,25 @@
+package org.jenkinsci.plugins.vagrant;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+class PerformVagrantDestroy {
+  boolean performVagrantVmDestroy(VagrantWrapper wrapper) {
+    List<String> arg = new ArrayList<>();
+
+    arg.add("--force");
+
+    try {
+      return wrapper.executeCommand("destroy", arg);
+    } catch (IOException e) {
+      wrapper.log("Error starting up vagrant, caught IOException, message: " + e.getMessage());
+      wrapper.log(e);
+      return false;
+    } catch (InterruptedException e) {
+      wrapper.log("Error starting up vagrant, caught InterruptedException, message: " + e.getMessage());
+      wrapper.log(e);
+      return false;
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantBuildSettings.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantBuildSettings.java
@@ -1,0 +1,82 @@
+package org.jenkinsci.plugins.vagrant;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Descriptor;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+public class VagrantBuildSettings extends BuildWrapper {
+    private final String vagrantFile;
+    private final String vagrantVm;
+    private final boolean destroyAfterBuild;
+
+    @SuppressWarnings("WeakerAccess")
+    @Extension
+    public static final BuildWrapperDescriptor DESCRIPTOR = new DescriptorImpl();
+
+    @DataBoundConstructor
+    public VagrantBuildSettings(String vagrantFile, String vagrantVm, boolean destroyAfterBuild) {
+        this.vagrantFile = vagrantFile;
+        this.vagrantVm = vagrantVm;
+        this.destroyAfterBuild = destroyAfterBuild;
+    }
+
+    @Override
+    public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException,
+            InterruptedException {
+        return new VagrantBuildSettingsEnvironment();
+    }
+
+    public String getVagrantFile() {
+        return vagrantFile;
+    }
+
+    public String getVagrantVm() {
+        return vagrantVm;
+    }
+
+    public boolean isDestroyAfterBuild() {
+        return destroyAfterBuild;
+    }
+
+    @Override
+    public Descriptor<BuildWrapper> getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    private static class DescriptorImpl extends BuildWrapperDescriptor {
+
+        @Override
+        public boolean isApplicable(AbstractProject<?, ?> item) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Vagrant settings";
+        }
+    }
+
+    public class VagrantBuildSettingsEnvironment extends Environment {
+        public VagrantBuildSettings getBuildSettings() {
+            return VagrantBuildSettings.this;
+        }
+
+        @Override
+        public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
+            if (isDestroyAfterBuild()) {
+                VagrantWrapper wrapper = VagrantWrapper.createVagrantWrapper(vagrantFile, vagrantVm, build, null, listener);
+                return new PerformVagrantDestroy().performVagrantVmDestroy(wrapper);
+
+            }
+            return true;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantBuildSettings.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantBuildSettings.java
@@ -15,17 +15,15 @@ import java.io.IOException;
 public class VagrantBuildSettings extends BuildWrapper {
     private final String vagrantFile;
     private final String vagrantVm;
-    private final boolean destroyAfterBuild;
 
     @SuppressWarnings("WeakerAccess")
     @Extension
     public static final BuildWrapperDescriptor DESCRIPTOR = new DescriptorImpl();
 
     @DataBoundConstructor
-    public VagrantBuildSettings(String vagrantFile, String vagrantVm, boolean destroyAfterBuild) {
+    public VagrantBuildSettings(String vagrantFile, String vagrantVm) {
         this.vagrantFile = vagrantFile;
         this.vagrantVm = vagrantVm;
-        this.destroyAfterBuild = destroyAfterBuild;
     }
 
     @Override
@@ -40,10 +38,6 @@ public class VagrantBuildSettings extends BuildWrapper {
 
     public String getVagrantVm() {
         return vagrantVm;
-    }
-
-    public boolean isDestroyAfterBuild() {
-        return destroyAfterBuild;
     }
 
     @Override
@@ -71,11 +65,6 @@ public class VagrantBuildSettings extends BuildWrapper {
 
         @Override
         public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-            if (isDestroyAfterBuild()) {
-                VagrantWrapper wrapper = VagrantWrapper.createVagrantWrapper(vagrantFile, vagrantVm, build, null, listener);
-                return new PerformVagrantDestroy().performVagrantVmDestroy(wrapper);
-
-            }
             return true;
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantDestroyCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantDestroyCommand.java
@@ -5,8 +5,10 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
-import hudson.model.Descriptor;
-import hudson.tasks.Builder;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -16,7 +18,7 @@ import java.util.List;
 /**
 * Created by elad on 9/18/14.
 */
-public class VagrantDestroyCommand extends Builder {
+public class VagrantDestroyCommand extends Recorder {
   private VagrantWrapper wrapper;
 
   @Extension
@@ -37,7 +39,7 @@ public class VagrantDestroyCommand extends Builder {
   }
 
   @Override
-  public Descriptor<Builder> getDescriptor() {
+  public BuildStepDescriptor<Publisher> getDescriptor() {
     return DESCRIPTOR;
   }
 
@@ -62,7 +64,12 @@ public class VagrantDestroyCommand extends Builder {
     }
   }
 
-  public static final class VagrantDestroyCommandDescriptor extends Descriptor<Builder> {
+  @Override
+  public BuildStepMonitor getRequiredMonitorService() {
+    return BuildStepMonitor.NONE;
+  }
+
+  public static final class VagrantDestroyCommandDescriptor extends BuildStepDescriptor<Publisher> {
 
     public String getDisplayName() {
       return "Destroy a Vagrant VM";

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantDestroyCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantDestroyCommand.java
@@ -5,10 +5,8 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
-import hudson.tasks.BuildStepDescriptor;
-import hudson.tasks.BuildStepMonitor;
-import hudson.tasks.Publisher;
-import hudson.tasks.Recorder;
+import hudson.model.Descriptor;
+import hudson.tasks.Builder;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -18,7 +16,7 @@ import java.util.List;
 /**
 * Created by elad on 9/18/14.
 */
-public class VagrantDestroyCommand extends Recorder {
+public class VagrantDestroyCommand extends Builder {
   private VagrantWrapper wrapper;
 
   @Extension
@@ -39,7 +37,7 @@ public class VagrantDestroyCommand extends Recorder {
   }
 
   @Override
-  public BuildStepDescriptor<Publisher> getDescriptor() {
+  public Descriptor<Builder> getDescriptor() {
     return DESCRIPTOR;
   }
 
@@ -64,12 +62,7 @@ public class VagrantDestroyCommand extends Recorder {
     }
   }
 
-  @Override
-  public BuildStepMonitor getRequiredMonitorService() {
-    return BuildStepMonitor.NONE;
-  }
-
-  public static final class VagrantDestroyCommandDescriptor extends BuildStepDescriptor<Publisher> {
+  public static final class VagrantDestroyCommandDescriptor extends Descriptor<Builder> {
 
     public String getDisplayName() {
       return "Destroy a Vagrant VM";

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantDestroyCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantDestroyCommand.java
@@ -9,31 +9,29 @@ import hudson.model.Descriptor;
 import hudson.tasks.Builder;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
 * Created by elad on 9/18/14.
 */
 public class VagrantDestroyCommand extends Builder {
-  private VagrantWrapper wrapper;
+  private final String vagrantFile;
+  private final String vagrantVm;
 
+  @SuppressWarnings("WeakerAccess")
   @Extension
   public static final VagrantDestroyCommandDescriptor DESCRIPTOR = new VagrantDestroyCommandDescriptor();
 
   @DataBoundConstructor
   public VagrantDestroyCommand(String vagrantFile, String vagrantVm) {
-    this.wrapper = new VagrantWrapper(vagrantFile, vagrantVm);
+    this.vagrantFile = vagrantFile;
+    this.vagrantVm = vagrantVm;
   }
 
   public String getVagrantFile() {
-
-    return wrapper.getVagrantFile();
+    return vagrantFile;
   }
 
   public String getVagrantVm() {
-    return this.wrapper.getVagrantVm();
+    return vagrantVm;
   }
 
   @Override
@@ -42,24 +40,8 @@ public class VagrantDestroyCommand extends Builder {
   }
 
   public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-    this.wrapper.setBuild(build);
-    this.wrapper.setLauncher(launcher);
-    this.wrapper.setListener(listener);
-    List<String> arg = new ArrayList<String>();
-
-    arg.add("--force");
-
-    try {
-      return this.wrapper.executeCommand("destroy", arg);
-    } catch (IOException e) {
-      wrapper.log("Error starting up vagrant, caught IOException, message: " + e.getMessage());
-      wrapper.log(e);
-      return false;
-    } catch (InterruptedException e) {
-      wrapper.log("Error starting up vagrant, caught InterruptedException, message: " + e.getMessage());
-      wrapper.log(e);
-      return false;
-    }
+    VagrantWrapper wrapper = VagrantWrapper.createVagrantWrapper(vagrantFile, vagrantVm, build, launcher, listener);
+    return new PerformVagrantDestroy().performVagrantVmDestroy(wrapper);
   }
 
   public static final class VagrantDestroyCommandDescriptor extends Descriptor<Builder> {

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantDestroyPostCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantDestroyPostCommand.java
@@ -19,23 +19,25 @@ import java.util.List;
  * Destroy Vagrant VM in Post-build actions.
  */
 public class VagrantDestroyPostCommand extends Recorder {
-  private VagrantWrapper wrapper;
+  private final String vagrantFile;
+  private final String vagrantVm;
 
+  @SuppressWarnings("WeakerAccess")
   @Extension
   public static final VagrantDestroyCommandDescriptor DESCRIPTOR = new VagrantDestroyCommandDescriptor();
 
   @DataBoundConstructor
   public VagrantDestroyPostCommand(String vagrantFile, String vagrantVm) {
-    this.wrapper = new VagrantWrapper(vagrantFile, vagrantVm);
+    this.vagrantFile = vagrantFile;
+    this.vagrantVm = vagrantVm;
   }
 
   public String getVagrantFile() {
-
-    return wrapper.getVagrantFile();
+    return vagrantFile;
   }
 
   public String getVagrantVm() {
-    return this.wrapper.getVagrantVm();
+    return vagrantVm;
   }
 
   @Override
@@ -44,24 +46,8 @@ public class VagrantDestroyPostCommand extends Recorder {
   }
 
   public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-    this.wrapper.setBuild(build);
-    this.wrapper.setLauncher(launcher);
-    this.wrapper.setListener(listener);
-    List<String> arg = new ArrayList<String>();
-
-    arg.add("--force");
-
-    try {
-      return this.wrapper.executeCommand("destroy", arg);
-    } catch (IOException e) {
-      wrapper.log("Error starting up vagrant, caught IOException, message: " + e.getMessage());
-      wrapper.log(e);
-      return false;
-    } catch (InterruptedException e) {
-      wrapper.log("Error starting up vagrant, caught InterruptedException, message: " + e.getMessage());
-      wrapper.log(e);
-      return false;
-    }
+    VagrantWrapper wrapper = VagrantWrapper.createVagrantWrapper(vagrantFile, vagrantVm, build, launcher, listener);
+    return new PerformVagrantDestroy().performVagrantVmDestroy(wrapper);
   }
 
   @Override

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantProvisionCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantProvisionCommand.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.vagrant;
 
 /**
-* Created by elad on 9/18/14.
-*/
+ * Created by elad on 9/18/14.
+ */
 
 import hudson.Launcher;
 import hudson.Extension;
@@ -17,16 +17,16 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class VagrantProvisionCommand extends Builder  {
-
+public class VagrantProvisionCommand extends Builder {
+  private final String vagrantFile;
+  private final String vagrantVm;
   private final String provisioners;
   private final boolean parallel;
 
-  private VagrantWrapper wrapper;
-
   @DataBoundConstructor
   public VagrantProvisionCommand(String vagrantFile, String vagrantVm, String provisioners, boolean parallel) {
-    this.wrapper = new VagrantWrapper(vagrantFile, vagrantVm);
+    this.vagrantFile = vagrantFile;
+    this.vagrantVm = vagrantVm;
     this.parallel = parallel;
     this.provisioners = provisioners;
   }
@@ -40,12 +40,11 @@ public class VagrantProvisionCommand extends Builder  {
   }
 
   public String getVagrantFile() {
-    return wrapper.getVagrantFile();
-
+    return vagrantFile;
   }
 
   public String getVagrantVm() {
-    return this.wrapper.getVagrantVm();
+    return vagrantVm;
   }
 
   @Override
@@ -54,28 +53,26 @@ public class VagrantProvisionCommand extends Builder  {
   }
 
   public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-    this.wrapper.setBuild(build);
-    this.wrapper.setLauncher(launcher);
-    this.wrapper.setListener(listener);
-    List<String> arg = new ArrayList<String>();
+    VagrantWrapper wrapper = VagrantWrapper.createVagrantWrapper(vagrantFile, vagrantVm, build, launcher, listener);
 
+    List<String> arg = new ArrayList<>();
     if (parallel) {
       arg.add("--parallel");
     }
-
     if (provisioners != null && !provisioners.isEmpty()) {
       arg.add("--provision-with");
       arg.add(provisioners);
     }
 
     try {
-      return this.wrapper.executeCommand("provision", arg);
+      return wrapper.executeCommand("provision", arg);
     } catch (IOException e) {
       listener.getLogger().println("Error starting up vagrant, caught IOException, message: " + e.getMessage());
       wrapper.log(e);
       return false;
     } catch (InterruptedException e) {
-      listener.getLogger().println("Error starting up vagrant, caught InterruptedException, message: " + e.getMessage());
+      listener.getLogger().println("Error starting up vagrant, caught InterruptedException, message: " + e.getMessage
+              ());
       wrapper.log(e);
       return false;
     }

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantSshCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantSshCommand.java
@@ -17,65 +17,42 @@ import java.util.List;
  * Created by elad on 10/13/14.
  */
 public class VagrantSshCommand extends Builder {
-
-  private String command;
-  private boolean asRoot;
-  private VagrantWrapper wrapper;
+  private final String vagrantFile;
+  private final String vagrantVm;
+  private final String command;
+  private final boolean asRoot;
 
   @DataBoundConstructor
   public VagrantSshCommand(String vagrantFile, String vagrantVm, String command, boolean asRoot) {
-    this.wrapper = new VagrantWrapper(vagrantFile, vagrantVm);
+    this.vagrantFile = vagrantFile;
+    this.vagrantVm = vagrantVm;
     this.command = command;
     this.asRoot = asRoot;
   }
 
-  /**
-   *
-   * @return
-   */
   public String getCommand() {
     return command;
   }
 
-  /**
-   *
-   * @param command
-   */
-  public void setCommand(String command) {
-    this.command = command;
-  }
-
-  /**
-   *
-   * @return
-   */
   public boolean isAsRoot() {
     return asRoot;
   }
 
-  /**
-   *
-   * @param asRoot
-   */
-  public void setAsRoot(boolean asRoot) {
-    this.asRoot = asRoot;
-  }
-
   public String getVagrantFile() {
-    return wrapper.getVagrantFile();
+    return vagrantFile;
   }
 
   public String getVagrantVm() {
-    return this.wrapper.getVagrantVm();
+    return vagrantVm;
   }
 
+  @SuppressWarnings("WeakerAccess")
   @Extension
   public static final VagrantSshCommandDescriptor DESCRIPTOR = new VagrantSshCommandDescriptor();
 
   public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-    this.wrapper.setBuild(build);
-    this.wrapper.setLauncher(launcher);
-    this.wrapper.setListener(listener);
+    VagrantWrapper wrapper = VagrantWrapper.createVagrantWrapper(vagrantFile, vagrantVm, build, launcher, listener);
+
     List<String> arg = new ArrayList<String>();
 
     arg.add("--command");
@@ -86,7 +63,7 @@ public class VagrantSshCommand extends Builder {
     }
 
     try {
-      return this.wrapper.executeCommand("ssh", arg);
+      return wrapper.executeCommand("ssh", arg);
     } catch (IOException e) {
       wrapper.log("Error starting up vagrant, caught IOException, message: " + e.getMessage());
       wrapper.log(e);

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantUpCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantUpCommand.java
@@ -7,6 +7,7 @@ package org.jenkinsci.plugins.vagrant;
 import hudson.Launcher;
 import hudson.Extension;
 import hudson.model.Descriptor;
+import hudson.model.Environment;
 import hudson.tasks.Builder;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -20,10 +21,10 @@ import java.util.TreeMap;
 
 
 public class VagrantUpCommand extends Builder {
-
-  private boolean destroyOnError;
-  private String provider;
-  private VagrantWrapper wrapper;
+  private final String vagrantFile;
+  private final String vagrantVm;
+  private final boolean destroyOnError;
+  private final String provider;
 
   public boolean isDontKillMe() {
     return dontKillMe;
@@ -35,12 +36,15 @@ public class VagrantUpCommand extends Builder {
 
   private boolean dontKillMe;
 
+  @SuppressWarnings("WeakerAccess")
   @Extension
   public static final VagrantUpCommandDescriptor DESCRIPTOR = new VagrantUpCommandDescriptor();
 
   @DataBoundConstructor
-  public VagrantUpCommand(String vagrantFile, String vagrantVm, boolean destroyOnError, String provider, boolean dontKillMe) {
-    this.wrapper = new VagrantWrapper(vagrantFile, vagrantVm);
+  public VagrantUpCommand(String vagrantFile, String vagrantVm, boolean destroyOnError, String provider, boolean
+          dontKillMe) {
+    this.vagrantFile = vagrantFile;
+    this.vagrantVm = vagrantVm;
     this.destroyOnError = destroyOnError;
     this.provider = provider;
     this.dontKillMe = dontKillMe;
@@ -50,24 +54,16 @@ public class VagrantUpCommand extends Builder {
     return destroyOnError;
   }
 
-  public void setDestroyOnError(boolean destroyOnError) {
-    this.destroyOnError = destroyOnError;
-  }
-
   public String getProvider() {
     return provider;
   }
 
-  public void setProvider(String provider) {
-    this.provider = provider;
-  }
-
   public String getVagrantFile() {
-    return wrapper.getVagrantFile();
+    return vagrantFile;
   }
 
   public String getVagrantVm() {
-    return this.wrapper.getVagrantVm();
+    return vagrantVm;
   }
 
   @Override
@@ -76,14 +72,12 @@ public class VagrantUpCommand extends Builder {
     return DESCRIPTOR;
   }
 
-
   public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
-    TreeMap<String, String> additinalVars = new TreeMap<String, String>();
+    TreeMap<String, String> additionalVars = new TreeMap<>();
 
-    this.wrapper.setBuild(build);
-    this.wrapper.setLauncher(launcher);
-    this.wrapper.setListener(listener);
-    List<String> arg = new ArrayList<String>();
+    VagrantWrapper wrapper = VagrantWrapper.createVagrantWrapper(vagrantFile, vagrantVm, build, launcher, listener);
+
+    List<String> arg = new ArrayList<>();
 
     if (destroyOnError) {
       arg.add("--destroy-on-error");
@@ -94,11 +88,11 @@ public class VagrantUpCommand extends Builder {
     }
 
     if (this.dontKillMe) {
-      additinalVars.put("BUILD_ID", "dontKillMe");
+      additionalVars.put("BUILD_ID", "dontKillMe");
     }
 
     try {
-      return this.wrapper.executeCommand("up", arg, additinalVars);
+      return wrapper.executeCommand("up", arg, additionalVars);
     } catch (IOException e) {
       wrapper.log("Error starting up vagrant, caught IOException, message: " + e.getMessage());
       wrapper.log(e);
@@ -112,17 +106,10 @@ public class VagrantUpCommand extends Builder {
 
   public static final class VagrantUpCommandDescriptor extends Descriptor<Builder> {
 
-    /**
-     * Default constructor
-     */
     public VagrantUpCommandDescriptor() {
       load();
     }
 
-    /**
-     *
-     * @return
-     */
     public String getDisplayName() {
       return "Boot up Vagrant VM";
     }

--- a/src/main/java/org/jenkinsci/plugins/vagrant/VagrantWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/vagrant/VagrantWrapper.java
@@ -60,22 +60,25 @@ public class VagrantWrapper {
 
   static VagrantWrapper createVagrantWrapper(String vagrantFile, String vagrantVm, AbstractBuild build,
                                              Launcher launcher, BuildListener listener) {
-    String vagrantFileToUse = vagrantFile;
-    String vagrantVmToUse = vagrantVm;
+    final String vagrantFileToUse;
+    final String vagrantVmToUse;
 
     VagrantBuildSettings globalSettings = extractSettingsFromBuild(build);
-    if (globalSettings != null) {
-      if (isEmptyOrNull(vagrantFileToUse) && !isEmptyOrNull(globalSettings.getVagrantFile())) {
+    if (globalSettings == null) {
+      vagrantFileToUse = vagrantFile;
+      vagrantVmToUse = vagrantVm;
+    } else {
+      if (!isEmptyOrNull(vagrantFile)) {
+        vagrantFileToUse = vagrantFile;
+      } else {
         vagrantFileToUse = globalSettings.getVagrantFile();
       }
 
-      if (isEmptyOrNull(vagrantVmToUse) && !isEmptyOrNull(globalSettings.getVagrantVm())) {
+      if (!isEmptyOrNull(vagrantVm)) {
+        vagrantVmToUse = vagrantVm;
+      } else {
         vagrantVmToUse = globalSettings.getVagrantVm();
       }
-    }
-
-    if (isEmptyOrNull(vagrantFileToUse)) {
-      throw new RuntimeException("Vagrantfile is not specified");
     }
 
     return new VagrantWrapper(vagrantFileToUse, vagrantVmToUse, build, launcher, listener);

--- a/src/main/resources/org/jenkinsci/plugins/vagrant/VagrantBuildSettings/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vagrant/VagrantBuildSettings/config.jelly
@@ -1,0 +1,12 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:entry title="Vagrantfile path" field="vagrantFile">
+        <f:textbox default=""/>
+    </f:entry>
+    <f:entry title="Vagrant VM name" field="vagrantVm">
+        <f:textbox default=""/>
+    </f:entry>
+  <f:entry title="Destroy after build" field="parallel">
+    <f:checkbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vagrant/VagrantBuildSettings/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/vagrant/VagrantBuildSettings/config.jelly
@@ -1,12 +1,10 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-	<f:entry title="Vagrantfile path" field="vagrantFile">
-        <f:textbox default=""/>
-    </f:entry>
-    <f:entry title="Vagrant VM name" field="vagrantVm">
-        <f:textbox default=""/>
-    </f:entry>
-  <f:entry title="Destroy after build" field="parallel">
-    <f:checkbox/>
+  <f:entry title="Vagrantfile path" field="vagrantFile">
+    <f:textbox default=""/>
+  </f:entry>
+  <f:entry title="Vagrant VM name" field="vagrantVm">
+    <f:textbox default=""/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/vagrant/VagrantBuildSettings/help-vagrantFile.html
+++ b/src/main/resources/org/jenkinsci/plugins/vagrant/VagrantBuildSettings/help-vagrantFile.html
@@ -1,0 +1,5 @@
+<div>
+  Either path with or without the vagrant file, can be relative or absolute. Relative path will be relatively to the workspace path.
+  <br />
+  This property is used, only when no Vagrantfile is specified in particular step.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/vagrant/VagrantBuildSettings/help-vagrantVm.html
+++ b/src/main/resources/org/jenkinsci/plugins/vagrant/VagrantBuildSettings/help-vagrantVm.html
@@ -1,0 +1,5 @@
+<div>
+  The vm name to run the step on.
+  <br />
+  This property is used, only when no VagrantVm is specified in particular step.
+</div>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-46233
 - added "global" settings for Vagrantfile and VagrantVm
 - this global settings is taken when particular step's field is empty

benefit => user don't have to refill same vagrantfile/vagrantvm to each step, but still have power to do so. 